### PR TITLE
chore: add horizontal scroll to tables

### DIFF
--- a/djangoproyect/applications/requests/templates/show-requests.html
+++ b/djangoproyect/applications/requests/templates/show-requests.html
@@ -25,8 +25,8 @@
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
     {% endif %}
-    <div class="container col-12">
-        <table id="requestsTable" class="table table-bordered overflow-x-auto">
+    <div class="container col-12 overflow-x-scroll">
+        <table id="requestsTable" class="table table-bordered">
             <thead>
                 <tr>
                     <th>ID</th>

--- a/djangoproyect/applications/teams/templates/edit-team.html
+++ b/djangoproyect/applications/teams/templates/edit-team.html
@@ -7,12 +7,24 @@ Cambiar líder de equipo
 {% block content %}
 
 <div class="container">
-    <form action="" method="POST">
-        {% csrf_token %}
-        {{form.as_p}}
-        <button type="submit" class="btn btn-primary">Guardar selección <i class="fa fa-save"></i></button>
-        <a href="/teams/" class="btn btn-danger">Cancelar <i class="fa fa-times"></i></a>
-    </form>
+    <div class="card">
+        <div class="card-body p-4">
+            <h2>Editar Equipo</h2>
+            <form method="post">
+                {% csrf_token %}
+                {{form.as_p}}
+                <div class="mt-4 mx-auto col-md-4 d-flex justify-content-between">
+                    <div>
+                        <a href="/teams" class="btn btn-danger">Cancelar <i class="fa fa-times"></i></a>
+                    </div>
+                    <div>
+                        <button type="submit" class="btn btn-primary">Guardar <i class="fa fa-user-plus"></i></button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
 </div>
+
 
 {% endblock %}

--- a/djangoproyect/applications/teams/templates/show-teams.html
+++ b/djangoproyect/applications/teams/templates/show-teams.html
@@ -15,7 +15,7 @@ Equipos
             <a href="/teams/add-team-form" class="btn btn-primary">Crear Equipo <i class="fa fa-plus"></i></a>
         </div>
     </div>
-    <div class="container overflow-auto-container">
+    <div class="container overflow-auto-container overflow-x-scroll">
         <table id="teamsTable" class="table table-bordered">
             <thead>
                 <tr>


### PR DESCRIPTION
Why: This PR is important because it allows users to access the application via mobile comfortably, as well as in different screen resolutions.

What: This changes the way tables are displayed in the interface, now they can be scrolled horizontally without moving the navigation too. It ensures that either the least significant part of the information is displayed and is not affected by the screen limitations, no matter the space is reduced horizontally or vertically.

ToDo: This commit is not the end, but the beginning of a new era, a new stage for this project to support any kind of device that can be imagined. This is a little step for the bootstrap, and a great step for the tailwind css.
Indeed, this change encourages the team development to improve the user interface, even though the information is displayed in a ordered way, it can be better in terms of arranging the items and distributing them taking advantage of the screen attributes.

 QA: To teset that this is working, I personally take my own device and appreciate the advantages of taking a responsive interface, also, used the inspection tool that edge provides to check how is the interface displayed when reducing the space vertically and horizontally.