### PR TITLE
doc: add request app code documentation

### DIFF
--- a/djangoproyect/applications/requests/apps.py
+++ b/djangoproyect/applications/requests/apps.py
@@ -1,6 +1,21 @@
+"""
+Request app
+
+This module defines the configuration for the "requests" Django app.
+"""
 from django.apps import AppConfig
 
 
 class RequestsConfig(AppConfig):
+    """
+    Class: RequestsConfig
+
+    This class represents the configuration for the "requests" Django app.
+
+    Attributes:
+        default_auto_field (str): The default primary key field type.
+        name (str): The name of the Django app.
+    """
+
     default_auto_field = "django.db.models.BigAutoField"
     name = "applications.requests"


### PR DESCRIPTION
Why:  Adds the request app documentation in the code

What: Adds a simple but powerful description for the request app archive in the request module 

ToDo: Continue documenting the module

QA: Nothing!