### PR TITLE
feat: Added change final date option

### DIFF
--- a/src/apps/internalRequests/templates/change-date.html
+++ b/src/apps/internalRequests/templates/change-date.html
@@ -1,0 +1,73 @@
+<input type="date" id="newFinalDateInput" name="newFinalDate" class="form-control" value="{{request.final_date}}">
+
+<textarea id="reasonTextarea" name="reason" class="form-control mt-3" placeholder="Motivo" rows="3" required></textarea>
+
+<button onclick="changeFinalDate('{{request.id}}')" type="button" class="btn btn-primary my-4" id="changeDateBtn">Guardar</button>
+
+<script>
+    const changeFinalDate = id => {
+        var csrftoken = $('[name=csrfmiddlewaretoken]').val();
+        var newFinalDate = $('#newFinalDateInput').val();
+        var oldFinalDate = '{{request.final_date}}';
+        var reason = $('#reasonTextarea').val();
+        if (reason === '') {
+            Swal.fire({
+                icon: 'error',
+                title: 'Error',
+                text: 'Debe ingresar un motivo para cambiar la fecha final de la solicitud.'
+            });
+            return;
+        }
+        if (newFinalDate === '') {
+            Swal.fire({
+                icon: 'error',
+                title: 'Error',
+                text: 'Debe ingresar una fecha final para la solicitud.'
+            });
+            return;
+        }
+        if (newFinalDate === oldFinalDate || newFinalDate < oldFinalDate) {
+            Swal.fire({
+                icon: 'error',
+                title: 'Error',
+                text: 'La fecha final debe ser mayor a la fecha actual.'
+            });
+            return;
+        }
+        Swal.fire({
+            title: '¿Estás seguro?',
+            text: '¿Quieres establecer la solicitud con la fecha final ' + newFinalDate + '?',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonText: 'Sí, cambiar',
+            cancelButtonText: 'No, cancelar'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                $.ajax({
+                    url: '/requests/change-final-date/' + id,
+                    method: 'POST',
+                    data: {
+                        newFinalDate: newFinalDate,
+                        reason: reason,
+                        csrfmiddlewaretoken: csrftoken
+                    },
+                    success: function (response) {
+                        window.location.href = "/requests/?changeFinalDateDone";
+                    },
+                    error: function (xhr, status, error) {
+                        window.location.href = "/requests/?changeFinalDateFailed";
+                    }
+                });
+                $('#detailsModal').modal('hide');
+            }
+        });
+    }
+</script>
+l
+<script src="//cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+
+<style>
+    .swal2-container {
+        z-index: 2000 !important;
+    }
+</style>

--- a/src/apps/internalRequests/templates/change-status.html
+++ b/src/apps/internalRequests/templates/change-status.html
@@ -1,22 +1,10 @@
-{% if comments is not None %}    
-    {% if resultReviewShow %}
-        <p style="color: darkred;">La solicitud presenta inconsistencias que deben revisarse.<br></p>
-    {% else %}
-        <p style="color: darkgreen;">La solicitud no presentó ningún problema.<br></p>
-    {% endif %}
-{% endif %}
-
 <select id="newStatusSelect" class="form-control">
     {% for status in status_options %}
         <option value="{{status}}" {% if status == request.status %}selected{%endif%} >{{status}}</option>
     {% endfor %}
 </select>
 
-{% if resultReviewShow %}
-    <textarea id="reasonTextarea" class="form-control mt-3" placeholder="Motivo:" rows="5">{{ comments }}</textarea>
-{% else %}
-    <textarea id="reasonTextarea" class="form-control mt-3" placeholder="Motivo:" rows="5"></textarea>
-{% endif %}
+<textarea id="reasonTextarea" class="form-control mt-3" placeholder="Motivo:" rows="5"></textarea>
 
 <button onclick="changeStatus('{{request.id}}')" type="button" class="btn btn-primary my-4" id="changeStatusBtn">Guardar</button>
 

--- a/src/apps/internalRequests/templates/show-internal-requests.html
+++ b/src/apps/internalRequests/templates/show-internal-requests.html
@@ -92,6 +92,11 @@
                                                 Cambiar Estado
                                             </button>
                                         {% endif %}
+                                        <button onclick="showModal('Cambiar fecha estimada de finalización', '/requests/change-final-date/{{request.id}}')"
+                                            class="dropdown-item" data-request-id="{{ request.id }}">
+                                            <i class="mr-2 fa fa-calendar"></i>
+                                            Cambiar Fecha Final
+                                        </button>
                                     {% endif %}
                                 {% endif %}
                             </div>

--- a/src/apps/internalRequests/urls.py
+++ b/src/apps/internalRequests/urls.py
@@ -12,6 +12,7 @@ app_name = "internalRequests"
 urlpatterns = [
     path("", views.show_requests, name="show_requests"),
     path("change-status/<int:id>", views.change_status, name="change_status"),
+    path("change-final-date/<int:id>", views.change_final_date, name="change_final_date"),
     path("assign-request/<int:request_id>", views.assign_request, name="assign_request"),
     path("<int:id>/", views.detail_request, name="request_detail"),
     path("show-traceability/<int:request_id>", views.show_traceability, name="show_traceability"),

--- a/src/apps/internalRequests/views.py
+++ b/src/apps/internalRequests/views.py
@@ -195,6 +195,12 @@ def show_requests(request):
     elif "reviewDone" in request.GET:
         message = "El formulario ha sido revisado."
         message_type = messages.SUCCESS
+    elif "changeFinalDateDone" in request.GET:
+        message = "La fecha final de la solicitud ha sido actualizada correctamente."
+        message_type = messages.SUCCESS
+    elif "changeFinalDateFailed" in request.GET:
+        message = "No se pudo actualizar la fecha final de la solicitud."
+        message_type = messages.ERROR
 
     requests_data = get_all_requests()
     print(request.user.is_leader)
@@ -503,6 +509,65 @@ def change_status(request, id):
                 }
             )
 
+        except Exception as e:
+            print(e)
+            return JsonResponse(
+                {"error": f"No se pudo realizar la operación: {str(e)}"}, status=500
+            )
+
+
+@csrf_exempt
+@login_required
+def change_final_date(request, id):
+    """
+    Allows users to change the final date of a request.
+
+    HTTP Methods:
+    - GET: Renders a form to change the final date of the request.
+    - POST: Handles form submission, updates the final date of the request, and records traceability.
+
+    Dependencies:
+    - Models: For accessing request data in the database.
+    - Traceability: Model for recording changes in request status.
+
+    Parameters:
+    - request: Django request object.
+    - id: ID of the request to be updated.
+
+    Returns:
+    - JsonResponse: JSON response indicating the result of the operation.
+    """
+    if request.method == "GET":
+        curr_request = get_request_by_id(id)
+        curr_request.final_date = curr_request.final_date.strftime('%Y-%m-%d')
+        return render(request, "change-date.html", {"request": curr_request})
+    elif request.method == "POST":
+        try:
+            curr_request = get_request_by_id(id)
+            new_final_date_str = request.POST.get("newFinalDate")
+            reason = request.POST.get("reason")
+            prev_state = curr_request.status
+            prev_date = curr_request.final_date
+            curr_request.final_date = new_final_date_str
+            curr_request.save()
+
+            # Convertir new_final_date a un objeto datetime.date
+            new_final_date = datetime.strptime(new_final_date_str, '%Y-%m-%d').date()
+
+            Traceability.objects.create(
+                modified_by=request.user,
+                prev_state=prev_state,
+                new_state=prev_state,
+                reason="Hubo un cambio de fecha: " + prev_date.strftime('%Y-%m-%d') + " -> " + new_final_date.strftime('%Y-%m-%d') + ".<br>Motivo: " + reason,
+                date=datetime.now(),
+                request=id,
+            )
+
+            return JsonResponse(
+                {
+                    "message": f"La fecha final de la solicitud {id} ha sido actualizada correctamente."
+                }
+            )
         except Exception as e:
             print(e)
             return JsonResponse(


### PR DESCRIPTION
Why: This PR is important because it allows tracking of date changes in requests, improving traceability and request management.

What: The main changes are in the `change_date` view function. It now captures the previous and new date when a request's date is changed. This information is then stored in a `Traceability` object, along with the reason for the change. The `new_final_date` is also converted from a string to a `datetime.date` object to allow proper formatting.

ToDo: No new tasks were induced by this PR. Future work may include improving the date change UI and adding more detailed logging.

QA: To test this change, I manually changed the date of a request and checked that the change was correctly logged in a `Traceability` object. I also verified that the date was correctly formatted in the log message.