### PR TITLE
fix: Phone inputs didn't work properly

### DIFF
--- a/src/apps/forms/templates/userForms/billing_account.html
+++ b/src/apps/forms/templates/userForms/billing_account.html
@@ -152,7 +152,7 @@
             <div class="col">
                 <div class="form-group">
                     <label for="phoneNumber">Teléfono</label>
-                    <input type="tel" class="form-control" id="phoneNumber" name="phoneNumber">
+                    <input type="tel" class="form-control" id="phoneNumber" name="phoneNumber" onkeypress="return event.charCode >= 48 && event.charCode <= 57">
                 </div>
             </div>
         </div>

--- a/src/apps/forms/views.py
+++ b/src/apps/forms/views.py
@@ -198,6 +198,7 @@ def travel_advance_request(request):
                 request,
                 "Formulario enviado correctamente. Puede revisarlo en la sección de Solicitudes.",
             )
+            context["form_data"] = None
             return render(
                 request, "userForms/travel_advance_request.html", {"today": date.today().isoformat()}
             )
@@ -296,8 +297,9 @@ def travel_expense_legalization(request):
                 request,
                 "Formulario enviado correctamente. Puede revisarlo en la sección de Solicitudes.",
             )
+            context["form_data"] = None
             return render(
-                request, "userForms/travel_expense_legalization.html", {"today": date.today().isoformat()}
+                request, "userForms/travel_expense_legalization.html", context
             )
 
 
@@ -374,8 +376,9 @@ def advance_legalization(request):
                 request,
                 "Formulario enviado correctamente. Puede revisarlo en la sección de Solicitudes.",
             )
+            context["form_data"] = None
             return render(
-                request, "userForms/advance_legalization.html", {"today": date.today().isoformat()}
+                request, "userForms/advance_legalization.html", context
             )
 
 
@@ -396,6 +399,7 @@ def billing_account(request):
         context["form_data"] = form_data
 
         if form_data.get("signatureStatus") != "Yes":
+            context["form_data"] = form_data
             messages.error(request, "Por favor, firme el formulario.")
             return render(
                 request,
@@ -436,10 +440,11 @@ def billing_account(request):
                 request,
                 "Formulario enviado correctamente. Puede revisarlo en la sección de Solicitudes.",
             )
+            context["form_data"] = None
             return render(
                 request,
                 "userForms/billing_account.html",
-                {"today": date.today().isoformat()},
+                context,
             )
 
 
@@ -492,4 +497,5 @@ def requisition(request):
                 request,
                 "Formulario enviado correctamente. Puede revisarlo en la sección de Solicitudes.",
             )
-            return render(request, "userForms/requisition.html", {"today": date.today().isoformat()})
+            context["form_data"] = None
+            return render(request, "userForms/requisition.html", context)

--- a/src/apps/internalRequests/templates/forms/billing_account.html
+++ b/src/apps/internalRequests/templates/forms/billing_account.html
@@ -213,7 +213,7 @@
             <div class="form-group">
                 <label for="phoneNumber">Teléfono</label>
                 <div class="d-flex justify-content-between">
-                    <input type="tel" class="form-control" id="phoneNumber" name="phoneNumber" value="{{ request.phone_number }}" disabled>
+                    <input type="tel" class="form-control" id="phoneNumber" name="phoneNumber" value="{{ request.phone_number }}" onkeypress="return event.charCode >= 48 && event.charCode <= 57" disabled>
                     {% if not user.is_applicant and not user.is_superuser and request.status == "EN REVISIÓN" %}
                         <input type="checkbox" class="btn-check" id="btncheckPhoneNumber" name="cellphoneCheck" data-message="Teléfono">
                         <label class="btn btn-outline-primary col-1 d-flex align-items-center" for="btncheckPhoneNumber" style="margin-left: 5px;"><i class="bi bi-check" style="transform: scale(1.5)"></i></label>


### PR DESCRIPTION
Why: This PR is important as it improves the data validation for the phone number field in the application. It ensures that only numeric input is accepted, enhancing data integrity and consistency.

What: A significant change has been made to the `billing_account.html` file. The phone number input field has been updated to only accept numeric input. This is achieved by using the `onkeypress` event to restrict the input to characters with charCodes between 48 and 57, which correspond to the numbers 0-9.

ToDo: No further tasks have been induced by this PR.

QA: To test whether this change works as expected, navigate to the page with the phone number input field. Try to input non-numeric characters into the field. The field should only accept numeric input.