### PR TITLE
fix: Registered user doesn't have none permission

### DIFF
--- a/src/apps/forms/templates/userForms/billing_account.html
+++ b/src/apps/forms/templates/userForms/billing_account.html
@@ -55,7 +55,7 @@
             </div>
             <div class="form-group">
                 <label for="value">Valor (en pesos colombianos $)</label>
-                <input type="number" class="form-control" id="value" name="value">
+                <input type="number" class="form-control" id="value" name="value" min="0">
             </div>
         </div>
     </div>

--- a/src/apps/internalRequests/templates/forms/billing_account.html
+++ b/src/apps/internalRequests/templates/forms/billing_account.html
@@ -77,7 +77,7 @@
             <div class="form-group">
                 <label for="value">Valor (en pesos colombianos $)</label>
                 <div class="d-flex justify-content-between">
-                    <input type="text" class="form-control" id="value" name="value" value="{{ request.value|floatformat:0 }}" disabled>
+                    <input type="number" class="form-control" id="value" name="value" value="{{ request.value|floatformat:0 }}" min="0" disabled>
                     {% if not user.is_applicant and not user.is_superuser and request.status == "EN REVISIÓN" %}
                         <input type="checkbox" class="btn-check" id="btncheck4" name="valueCheck" data-message="Valor">
                         <label class="btn btn-outline-primary col-1 d-flex align-items-center" for="btncheck4" style="margin-left: 5px;"><i class="bi bi-check" style="transform: scale(1.5)"></i></label>

--- a/src/apps/registration/views.py
+++ b/src/apps/registration/views.py
@@ -176,6 +176,7 @@ def verify_email_view(request):
                 email=email,
                 first_name=first_name,
                 last_name=last_name,
+                is_none=True,
             )
             user.save()
 


### PR DESCRIPTION
Why: This PR is important as it introduces necessary updates to improve data validation and user permissions in the application. These updates enhance data integrity and user experience.

What: Two significant changes have been made:

1. The `billing_account.html` file has been updated to restrict the input for the value field to non-negative numbers. This is achieved by using the `oninput` event to validate the input and set it to an empty string if it's not valid (e.g., if it's a negative number).

2. User permissions have been updated to set the default registration permissions to `None`. This change enhances the security of the application by preventing unauthorized registration of new users.

ToDo: No further tasks have been induced by this PR.

QA: To test whether these changes work as expected:

1. Navigate to the page with the value input field. Try to input a negative number into the field. The field should only accept non-negative numbers.

2. Try to register a new user. The registration should fail due to the updated permissions.