### PR TITLE
fix: Fixed reason data displaying in traceability

### DIFF
--- a/apps/internalRequests/templates/internalFormBlocks/reviewblock.html
+++ b/apps/internalRequests/templates/internalFormBlocks/reviewblock.html
@@ -88,10 +88,8 @@
                         reason = 'Enviado a Ventanilla Única, en espera de aprobación.';
                     } else if (action === 'devolver') {
                         newStatus = 'DEVUELTO';
-                        reason = "Se ha devuelto el formulario, puede corregirlo en la sección de solicitudes y enviarlo nuevamente"
                     } else if (action === 'rechazar') {
                         newStatus = 'RECHAZADO';
-                        reason = "El miembro/administrador de la Ventanilla Única ha rechazado la solicitud";
                     }
                     $.ajax({
                         url: '/requests/change-status/' + id + '/',


### PR DESCRIPTION
Why: This pr fixes the reason data displaying on notifications and traceability during requests revision.

What: Just deleted some lines that were putting a default reason.

ToDo: Nothing.

QA: Nothing.